### PR TITLE
Correct Typos

### DIFF
--- a/study.md
+++ b/study.md
@@ -35,7 +35,7 @@ Please note:
 
 -   [Getting Started with Rails — Ruby on Rails Guides](http://guides.rubyonrails.org/getting_started.html)
 
-## Define Model Responsiblities
+## Define Model Responsibilities
 
 In your own words, define what the responsibilities of the model layer are in
 Rails.
@@ -44,7 +44,7 @@ Rails.
 <!-- your answer here -->
 ```
 
-## Define Controller Responsiblities
+## Define Controller Responsibilities
 
 In your own words, define what the responsibilities of the controller layer are
 in Rails.
@@ -53,7 +53,7 @@ in Rails.
 <!-- your answer here -->
 ```
 
-## Define Router Responsiblities
+## Define Router Responsibilities
 
 In your own words, define what the router does in Rails.
 


### PR DESCRIPTION
Change "Responsiblities" to "Responsibilities" in the question headers.  Fixes #119.